### PR TITLE
chore: add root tsconfig and references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ Thumbs.db
 
 # Helm
 charts/*.tgz
+# TypeScript
+*.tsbuildinfo

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@backstage/cli/config/tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true,
+    "tsBuildInfoFile": "../../node_modules/.cache/tsc/app.tsbuildinfo",
+    "emitDeclarationOnly": false
+  }
+}

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@backstage/cli/config/tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true,
+    "tsBuildInfoFile": "../../node_modules/.cache/tsc/backend.tsbuildinfo",
+    "emitDeclarationOnly": false
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@backstage/cli/config/tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false
+  },
+  "files": [],
+  "references": [
+    { "path": "packages/app" },
+    { "path": "packages/backend" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add root TypeScript config extending Backstage default
- configure project references for app and backend packages
- ignore TypeScript build info files

## Testing
- `npx tsc --noEmit && rm -f tsconfig.tsbuildinfo && echo "tsc completed"`


------
https://chatgpt.com/codex/tasks/task_e_688e274143a8832288854bdfc5726a90