### PR TITLE
Fix TechDocs sidebar navigation

### DIFF
--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -58,7 +58,7 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
         <SidebarScrollWrapper>
           <SidebarItem icon={CatalogIcon} to="catalog" text="Catalog" />
           <SidebarItem icon={ApiIcon} to="api-docs" text="APIs" />
-          <SidebarItem icon={DocsIcon} to="techdocs" text="TechDocs" />
+          <SidebarItem icon={DocsIcon} to="docs" text="TechDocs" />
           <SidebarItem icon={CatalogIcon} to="catalog-graph" text="Graph" />
         </SidebarScrollWrapper>
       </SidebarGroup>


### PR DESCRIPTION
## Summary
- route TechDocs sidebar link to /docs

## Testing
- `npm test packages/app`
- `npm run start` (port 3200) and `curl -I http://localhost:3200/docs`


------
https://chatgpt.com/codex/tasks/task_e_688e274098108322ad0360548950b8f9