### PR TITLE
Remove unused SignInPage import

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: [require.resolve('@backstage/cli/config/eslint')],
+};

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -25,7 +25,6 @@ import { Root } from './components/Root';
 import {
   AlertDisplay,
   OAuthRequestDialog,
-  SignInPage,
 } from '@backstage/core-components';
 import { createApp } from '@backstage/app-defaults';
 import { AppRouter, FlatRoutes } from '@backstage/core-app-api';

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -40,6 +40,12 @@ const SidebarLogo = () => {
   );
 };
 
+const SidebarScrollWrapper = ({ children }: PropsWithChildren<{}>) => (
+  <div style={{ height: '100%', overflow: 'hidden auto' }}>
+    {children}
+  </div>
+);
+
 export const Root = ({ children }: PropsWithChildren<{}>) => (
   <SidebarPage>
     <BackstageSidebar>
@@ -74,11 +80,5 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
     </BackstageSidebar>
     {children}
   </SidebarPage>
-);
-
-const SidebarScrollWrapper = ({ children }: PropsWithChildren<{}>) => (
-  <div style={{ height: '100%', overflow: 'hidden auto' }}>
-    {children}
-  </div>
 );
 


### PR DESCRIPTION
## Summary
- remove unused `SignInPage` from core-components import block
- ensure sidebar wrapper is defined before usage and add ESLint config

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e27350a4483228846978cd3ffada6