### PR TITLE
feat: add events backend plugin

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -42,6 +42,12 @@ backend:
     connection: ':memory:'
   # workingDirectory: /tmp # Use this to configure a working directory for the scaffolder, defaults to the OS temp-dir
 
+events:
+  eventBus:
+    type: memory
+  eventStorage:
+    type: database
+
 integrations:
   gitlab:
     - host: gitlab.com
@@ -97,6 +103,8 @@ catalog:
   rules:
     - allow: [Component, System, API, Resource, Location]
   useUrlReadersSearch: true
+  events:
+    enabled: false
   locations:
     # Local example data, file locations are relative to the backend process, typically `packages/backend`
     - type: file

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -25,6 +25,7 @@
     "@backstage/plugin-app-backend": "^0.3.65",
     "@backstage/plugin-auth-backend": "^0.22.0",
     "@backstage/plugin-auth-backend-module-guest-provider": "^0.1.4",
+    "@backstage/plugin-events-backend": "^0.3.0",
     "@backstage/plugin-catalog-backend": "^1.22.0",
     "@backstage/plugin-catalog-backend-module-gitlab": "^0.3.0",
     "@backstage/plugin-catalog-backend-module-logs": "^0.0.1",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -5,7 +5,10 @@ const backend = createBackend();
 // App backend plugin
 backend.add(import('@backstage/plugin-app-backend'));
 
-// Catalog plugin  
+// Catalog plugin
 backend.add(import('@backstage/plugin-catalog-backend'));
+
+// Events plugin
+backend.add(import('@backstage/plugin-events-backend'));
 
 backend.start();


### PR DESCRIPTION
## Summary
- add @backstage/plugin-events-backend to backend dependencies
- register events backend plugin and disable catalog event publishing
- configure in-memory bus and database storage in app-config

## Testing
- `npm run lint` *(fails: git diff failed, origin/main unknown)*
- `npm run type-check` *(fails: Missing script "type-check")*
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e2b7617c0832298caf7ab131e78c7